### PR TITLE
GH-17 card preview enhancements

### DIFF
--- a/App/Bunnydex/CardDetailView.swift
+++ b/App/Bunnydex/CardDetailView.swift
@@ -8,6 +8,17 @@
 import SwiftUI
 import SwiftData
 
+extension CGSize {
+    static func +(lhs: Self, rhs: Self) -> Self {
+        Self(width: lhs.width + rhs.width, height: lhs.height + rhs.height)
+    }
+
+    static func +=(lhs: inout Self, rhs: Self) {
+        lhs.width += rhs.width
+        lhs.height += rhs.height
+    }
+}
+
 struct CardDetailView: View {
     let card: Card
     var imageId: String {
@@ -18,6 +29,9 @@ struct CardDetailView: View {
     @State private var currentZoom = 0.0
     @State private var totalZoom = 1.0
 
+    @State private var currentPan: CGSize = .zero
+    @State private var totalPan: CGSize = .zero
+
     var body: some View {
         List {
             if UIImage(named: imageId) != nil {
@@ -26,6 +40,7 @@ struct CardDetailView: View {
                     .scaledToFit()
                     .frame(maxWidth: .infinity, maxHeight: 200)
                     .scaleEffect(currentZoom + totalZoom)
+                    .offset(currentPan + totalPan)
                     .gesture(
                         MagnifyGesture()
                             .onChanged { value in
@@ -34,6 +49,16 @@ struct CardDetailView: View {
                             .onEnded { value in
                                 totalZoom += currentZoom
                                 currentZoom = 0
+                            }
+                    )
+                    .gesture(
+                        DragGesture()
+                            .onChanged { value in
+                                currentPan = value.translation
+                            }
+                            .onEnded { value in
+                                totalPan += currentPan
+                                currentPan = .zero
                             }
                     )
             }

--- a/App/Bunnydex/CardDetailView.swift
+++ b/App/Bunnydex/CardDetailView.swift
@@ -15,22 +15,27 @@ struct CardDetailView: View {
     }
     @Binding var path: NavigationPath
 
-    let columns = [
-        GridItem(.fixed(10), spacing: 15),
-        GridItem(.fixed(10), spacing: 15),
-        GridItem(.fixed(10), spacing: 15),
-        GridItem(.fixed(10), spacing: 15),
-        GridItem(.fixed(10), spacing: 15),
-    ]
+    @State private var currentZoom = 0.0
+    @State private var totalZoom = 1.0
 
     var body: some View {
         List {
             if UIImage(named: imageId) != nil {
                 Image(imageId)
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(width: 580, height: 200, alignment: .top)
-                    .offset(x: 0, y: -160)
+                    .scaledToFit()
+                    .frame(maxWidth: .infinity, maxHeight: 200)
+                    .scaleEffect(currentZoom + totalZoom)
+                    .gesture(
+                        MagnifyGesture()
+                            .onChanged { value in
+                                currentZoom = value.magnification - 1
+                            }
+                            .onEnded { value in
+                                totalZoom += currentZoom
+                                currentZoom = 0
+                            }
+                    )
             }
             Section {
                 LabeledContent("ID") {

--- a/App/Bunnydex/CardDetailView.swift
+++ b/App/Bunnydex/CardDetailView.swift
@@ -26,11 +26,7 @@ struct CardDetailView: View {
     }
     @Binding var path: NavigationPath
 
-    @State private var currentZoom = 0.0
-    @State private var totalZoom = 1.0
-
-    @State private var currentPan: CGSize = .zero
-    @State private var totalPan: CGSize = .zero
+    @State private var gestureValue = PanGestureValue.zero
 
     var body: some View {
         List {
@@ -39,28 +35,11 @@ struct CardDetailView: View {
                     .resizable()
                     .scaledToFit()
                     .frame(maxWidth: .infinity, maxHeight: 200)
-                    .scaleEffect(currentZoom + totalZoom)
-                    .offset(currentPan + totalPan)
-                    .gesture(
-                        MagnifyGesture()
-                            .onChanged { value in
-                                currentZoom = value.magnification - 1
-                            }
-                            .onEnded { value in
-                                totalZoom += currentZoom
-                                currentZoom = 0
-                            }
-                    )
-                    .gesture(
-                        DragGesture()
-                            .onChanged { value in
-                                currentPan = value.translation
-                            }
-                            .onEnded { value in
-                                totalPan += currentPan
-                                currentPan = .zero
-                            }
-                    )
+                    .scaleEffect(gestureValue.magnification)
+                    .offset(gestureValue.translation)
+                    .panGesture { value in
+                        gestureValue = value
+                    }
             }
             Section {
                 LabeledContent("ID") {

--- a/App/Bunnydex/CardDetailView.swift
+++ b/App/Bunnydex/CardDetailView.swift
@@ -26,7 +26,32 @@ struct CardDetailView: View {
     }
     @Binding var path: NavigationPath
 
-    @State private var gestureValue = PanGestureValue.zero
+    @State private var currentZoom = 0.0
+    @State private var finalZoom = 1.0
+    @State private var currentOffset: CGSize = .zero
+    @State private var finalOffset: CGSize = .zero
+
+    private var dragGesture: some Gesture {
+        DragGesture()
+            .onChanged { value in
+                currentOffset = value.translation
+            }
+            .onEnded({ value in
+                finalOffset += currentOffset
+                currentOffset = .zero
+            })
+    }
+
+    private var magnificationGesture: some Gesture {
+        MagnificationGesture()
+            .onChanged { amount in
+                currentZoom = amount - 1
+            }
+            .onEnded({ amount in
+                finalZoom += currentZoom
+                currentZoom = 0
+            })
+    }
 
     var body: some View {
         List {
@@ -35,11 +60,9 @@ struct CardDetailView: View {
                     .resizable()
                     .scaledToFit()
                     .frame(maxWidth: .infinity, maxHeight: 200)
-                    .scaleEffect(gestureValue.magnification)
-                    .offset(gestureValue.translation)
-                    .panGesture { value in
-                        gestureValue = value
-                    }
+                    .scaleEffect(currentZoom + finalZoom)
+                    .offset(currentOffset + finalOffset)
+                    .gesture(dragGesture.simultaneously(with: magnificationGesture))
             }
             Section {
                 LabeledContent("ID") {

--- a/App/Bunnydex/PanGesture.swift
+++ b/App/Bunnydex/PanGesture.swift
@@ -1,0 +1,93 @@
+//
+//  PanGesture.swift
+//  Bunnydex
+//
+//  Created by Neill Robson on 6/9/25.
+//
+
+import SwiftUI
+
+// REFERENCE: https://stackoverflow.com/questions/76001888/how-to-detect-2-finger-pan-gesture-in-swiftui
+
+struct PanGestureValue {
+    var location: CGPoint
+    var startLocation: CGPoint
+    var translation: CGSize
+    var magnification: Double
+
+    static let zero = PanGestureValue(location: .zero, startLocation: .zero, translation: .zero, magnification: 0)
+}
+
+class GestureObserver: ObservableObject {
+    @Published var value: PanGestureValue = .zero
+
+    private var touches = [[CGPoint]]()
+
+    func update(_ points: [CGPoint]) {
+        if points.isEmpty {
+            touches.removeAll()
+            return
+        }
+
+        // TODO: The remainder of this fn
+    }
+}
+
+private func CGPointDistance(from: CGPoint, to: CGPoint) -> CGFloat {
+    CGFloat(hypotf(Float(to.x - from.x), Float(to.y - from.y)))
+}
+
+struct PanGestureView: UIViewRepresentable {
+    var onTouch: ([CGPoint]) -> Void
+
+    func makeUIView(context: Context) -> PanGestureUIView {
+        let view = PanGestureUIView()
+        view.onTouch = onTouch
+        view.isMultipleTouchEnabled = true
+        return view
+    }
+
+    func updateUIView(_ uiView: PanGestureUIView, context: Context) {}
+}
+
+class PanGestureUIView: UIView {
+    var onTouch: (([CGPoint]) -> Void)?
+    private var activeTouches: [UITouch: CGPoint] = [:]
+
+    private func updateTouches(_ touches: Set<UITouch>) {
+        for touch in touches {
+            activeTouches[touch] = touch.location(in: self)
+        }
+        onTouch?(Array(activeTouches.values))
+    }
+
+    private func removeTouches(_ touches: Set<UITouch>) {
+        for touch in touches {
+            activeTouches.removeValue(forKey: touch)
+        }
+        onTouch?(Array(activeTouches.values))
+    }
+
+    // TODO: The override fucntions
+}
+
+struct PanGestureModifier: ViewModifier {
+    var onGesture: (PanGestureValue) -> Void
+    @StateObject private var gestureObserver = GestureObserver()
+
+    func body(content: Content) -> some View {
+        content
+            .overlay {
+                PanGestureView { touches in
+                    gestureObserver.update(touches)
+                    onGesture(gestureObserver.value)
+                }
+            }
+    }
+}
+
+extension View {
+    func panGesture(_ onGesture: @escaping (PanGestureValue) -> Void) -> some View {
+        self.modifier(PanGestureModifier(onGesture: onGesture))
+    }
+}


### PR DESCRIPTION
Went with a very simple implementation here.

It's only barely functional, still has issues:

- You can easily drag the card out of the viewport without the ability to drag it back in
- Zooming out feels inefficient
- Cannot zoom and drag simultaneously (probably by using two fingers for both actions?)
- There seems to be a lag when navigating between Views (error when debugging looks like `Hang detected: 0.33s (debugger attached, not reporting)`)

Eventually we might want to do something similar to `PanGesture`, perhaps using `SpatialEventGesture` to implement. For now, I just want to get an MVP out, but I'm leaving the `PanGesture` code in for reference down the line.

Closes GH-17.