### PR TITLE
GH-36 card creation flow

### DIFF
--- a/App/Bunnydex/BunnydexApp.swift
+++ b/App/Bunnydex/BunnydexApp.swift
@@ -12,7 +12,7 @@ import SwiftData
 struct BunnydexApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            MainView()
         }
         .modelContainer(appContainer)
     }

--- a/App/Bunnydex/model/Card/Card.swift
+++ b/App/Bunnydex/model/Card/Card.swift
@@ -31,7 +31,7 @@ extension CardModel {
      Handles initializing, inserting, and defining relationships for a new Card model object.
      */
     @discardableResult
-    static func create(json: Card, context: ModelContext, dice: [Die: DieModel], symbols: [Symbol: SymbolModel]) -> CardModel {
+    static func create(json: CardJSON, context: ModelContext, dice: [Die: DieModel], symbols: [Symbol: SymbolModel]) -> CardModel {
         let card = CardModel(json: json)
         context.insert(card)
 
@@ -42,19 +42,24 @@ extension CardModel {
     }
 }
 
-struct Card: Codable, Sendable, Hashable, Identifiable {
-    var id: String
+struct CardView: Sendable, Hashable, Identifiable {
+    let model: Model<CardModel>
+
+    var id: PersistentIdentifier { model.persistentIdentifier }
+
+    var cardId: String
     var title: String
     var type: CardType
     var deck: Deck
-    var bunnyRequirement: BunnyRequirement?
-    var dice: [Die]?
+    var bunnyRequirement: BunnyRequirement
+    var dice: [Die]
     var pawn: Pawn?
-    var symbols: [Symbol]?
-    var rules: [Rule]?
+    var symbols: [Symbol]
+    var rules: [Rule]
 
     init(_ card: CardModel) {
-        id = card.cardId
+        model = .init(card)
+        cardId = card.cardId
         title = card.title
         type = card.type
         deck = card.deck

--- a/App/Bunnydex/model/Card/CardJSON.swift
+++ b/App/Bunnydex/model/Card/CardJSON.swift
@@ -1,0 +1,33 @@
+//
+//  CardJSON.swift
+//  Bunnydex
+//
+//  Created by Neill Robson on 8/8/25.
+//
+
+import Foundation
+import SwiftData
+
+struct CardJSON: Codable, Sendable, Hashable, Identifiable {
+    var id: String
+    var title: String
+    var type: CardType
+    var deck: Deck
+    var bunnyRequirement: BunnyRequirement?
+    var dice: [Die]?
+    var pawn: Pawn?
+    var symbols: [Symbol]?
+    var rules: [Rule]?
+
+    init(_ card: CardModel) {
+        id = card.cardId
+        title = card.title
+        type = card.type
+        deck = card.deck
+        bunnyRequirement = card.bunnyRequirement
+        dice = card.dice.map(\.die)
+        pawn = card.pawn
+        symbols = card.symbols.map(\.symbol)
+        rules = card.orderedRules.map(\.rule)
+    }
+}

--- a/App/Bunnydex/model/Card/CardMigrationPlan.swift
+++ b/App/Bunnydex/model/Card/CardMigrationPlan.swift
@@ -12,9 +12,9 @@ import SwiftData
 extension MigrationStage: @unchecked @retroactive Sendable { }
 
 enum CardMigrationPlan: SchemaMigrationPlan {
-    static var schemas: [any VersionedSchema.Type] { [SchemaV1.self, SchemaV1_1.self, SchemaV2.self] }
+    static var schemas: [any VersionedSchema.Type] { [SchemaV1.self, SchemaV1_1.self, SchemaV2.self, SchemaV3.self] }
 
-    static var stages: [MigrationStage] { [migrateV1ToV1_1, migrateV1_1ToV2] }
+    static var stages: [MigrationStage] { [migrateV1ToV1_1, migrateV1_1ToV2, migrateV2ToV3] }
 
     static let migrateV1ToV1_1 = MigrationStage.custom(
         fromVersion: SchemaV1.self,
@@ -36,5 +36,10 @@ enum CardMigrationPlan: SchemaMigrationPlan {
     static let migrateV1_1ToV2 = MigrationStage.lightweight(
         fromVersion: SchemaV1_1.self,
         toVersion: SchemaV2.self
+    )
+
+    static let migrateV2ToV3 = MigrationStage.lightweight(
+        fromVersion: SchemaV2.self,
+        toVersion: SchemaV3.self
     )
 }

--- a/App/Bunnydex/model/Card/CardSchemaV1.swift
+++ b/App/Bunnydex/model/Card/CardSchemaV1.swift
@@ -24,7 +24,7 @@ extension SchemaV1 {
 
         var rules: [Rule]
 
-        init(json: Card) {
+        init(json: CardJSON) {
             id = json.id
             title = json.title
             rules = json.rules ?? []

--- a/App/Bunnydex/model/Card/CardSchemaV1_1.swift
+++ b/App/Bunnydex/model/Card/CardSchemaV1_1.swift
@@ -26,7 +26,7 @@ extension SchemaV1_1 {
 
         var rules: [Rule]
 
-        init(json: Card) {
+        init(json: CardJSON) {
             id = json.id
             title = json.title
             rules = json.rules ?? []

--- a/App/Bunnydex/model/Card/CardSchemaV2.swift
+++ b/App/Bunnydex/model/Card/CardSchemaV2.swift
@@ -25,7 +25,7 @@ extension SchemaV2 {
         @Relationship(deleteRule: .cascade, originalName: "newRules", inverse: \RuleModel.card)
         var rules: [RuleModel] = []
 
-        init(json: Card) {
+        init(json: CardJSON) {
             id = json.id
             title = json.title
 

--- a/App/Bunnydex/model/Card/CardSchemaV3.swift
+++ b/App/Bunnydex/model/Card/CardSchemaV3.swift
@@ -1,17 +1,22 @@
 //
-//  CardSchemaV2.swift
+//  CardSchemaV3.swift
 //  Bunnydex
 //
-//  Created by Neill Robson on 7/21/25.
+//  Created by Neill Robson on 8/2/25.
 //
 
 import Foundation
 import SwiftData
 
-extension SchemaV2 {
+extension SchemaV3 {
     @Model
     final class CardModel {
-        var id: String
+        var id: ObjectIdentifier {
+            ObjectIdentifier(self)
+        }
+
+        @Attribute(originalName: "id")
+        var cardId: String
         var title: String
         var rawType: Int
         var rawDeck: Int
@@ -22,11 +27,11 @@ extension SchemaV2 {
         var dice: [DieModel] = []
         @Relationship(inverse: \SymbolModel.cards)
         var symbols: [SymbolModel] = []
-        @Relationship(deleteRule: .cascade, originalName: "newRules", inverse: \RuleModel.card)
+        @Relationship(deleteRule: .cascade, inverse: \RuleModel.card)
         var rules: [RuleModel] = []
 
         init(json: Card) {
-            id = json.id
+            cardId = json.id
             title = json.title
 
             rawType = json.type.rawValue
@@ -39,7 +44,7 @@ extension SchemaV2 {
         }
 
         init() {
-            id = "0000"
+            cardId = "0000"
             title = "Placeholder"
 
             rawType = 0

--- a/App/Bunnydex/model/Card/CardSchemaV3.swift
+++ b/App/Bunnydex/model/Card/CardSchemaV3.swift
@@ -22,6 +22,7 @@ extension SchemaV3 {
         var rawDeck: Int
         var rawPawn: Int?
         var rawRequirement: Int
+        var custom: Bool = false
 
         @Relationship(inverse: \DieModel.cards)
         var dice: [DieModel] = []
@@ -52,6 +53,7 @@ extension SchemaV3 {
             rawRequirement = 0
 
             rawPawn = nil
+            custom = true
         }
 
         var orderedRules: [RuleModel] {

--- a/App/Bunnydex/model/Card/CardSchemaV3.swift
+++ b/App/Bunnydex/model/Card/CardSchemaV3.swift
@@ -30,7 +30,7 @@ extension SchemaV3 {
         @Relationship(deleteRule: .cascade, inverse: \RuleModel.card)
         var rules: [RuleModel] = []
 
-        init(json: Card) {
+        init(json: CardJSON) {
             cardId = json.id
             title = json.title
 

--- a/App/Bunnydex/model/Model.swift
+++ b/App/Bunnydex/model/Model.swift
@@ -1,0 +1,24 @@
+//
+//  Model.swift
+//  Bunnydex
+//
+//  Created by Neill Robson on 8/8/25.
+//
+
+import Foundation
+import SwiftData
+
+public struct Model<T: PersistentModel>: Sendable, Hashable, Identifiable {
+    public let persistentIdentifier: PersistentIdentifier
+    public var id: PersistentIdentifier.ID { persistentIdentifier.id }
+
+    public init(persistentIdentifier: PersistentIdentifier) {
+        self.persistentIdentifier = persistentIdentifier
+    }
+}
+
+extension Model {
+    public init(_ model: T) {
+        self.init(persistentIdentifier: model.persistentModelID)
+    }
+}

--- a/App/Bunnydex/model/PredicateBuilder.swift
+++ b/App/Bunnydex/model/PredicateBuilder.swift
@@ -50,7 +50,7 @@ func predicateBuilder(searchFilter: String = "", decks: Set<Deck> = [], types: S
                     rhs: PredicateExpressions.build_Equal(
                         lhs: PredicateExpressions.build_KeyPath(
                             root: PredicateExpressions.build_Arg(card),
-                            keyPath: \.id
+                            keyPath: \.cardId
                         ),
                         rhs: PredicateExpressions.build_Arg(searchFilter)
                     )

--- a/App/Bunnydex/model/Rule/Rule.swift
+++ b/App/Bunnydex/model/Rule/Rule.swift
@@ -7,7 +7,7 @@
 
 import SwiftData
 
-typealias RuleModel = SchemaV2.RuleModel
+typealias RuleModel = SchemaV3.RuleModel
 
 struct Rule: Codable, Hashable {
     var title: String

--- a/App/Bunnydex/model/Rule/RuleSchemaV3.swift
+++ b/App/Bunnydex/model/Rule/RuleSchemaV3.swift
@@ -1,0 +1,37 @@
+//
+//  RuleSchemaV3.swift
+//  Bunnydex
+//
+//  Created by Neill Robson on 8/2/25.
+//
+
+import SwiftData
+
+extension SchemaV3 {
+    @Model
+    final class RuleModel {
+        var id: ObjectIdentifier {
+            ObjectIdentifier(self)
+        }
+
+        var title: String
+        var text: String
+        var order: Int = 0
+
+        var card: CardModel?
+
+        init(_ rule: Rule) {
+            self.title = rule.title
+            self.text = rule.text
+        }
+
+        init(title: String = "", text: String = "") {
+            self.title = title
+            self.text = text
+        }
+
+        var rule: Rule {
+            .init(title: title, text: text)
+        }
+    }
+}

--- a/App/Bunnydex/model/Schema/SchemaV3.swift
+++ b/App/Bunnydex/model/Schema/SchemaV3.swift
@@ -1,0 +1,16 @@
+//
+//  SchemaV3.swift
+//  Bunnydex
+//
+//  Created by Neill Robson on 8/2/25.
+//
+
+import SwiftData
+
+enum SchemaV3 : VersionedSchema {
+    static var versionIdentifier: Schema.Version { .init(3, 0, 0) }
+
+    static var models: [any PersistentModel.Type] {
+        [CardModel.self, RuleModel.self]
+    }
+}

--- a/App/Bunnydex/model/SwiftDataAppContainer.swift
+++ b/App/Bunnydex/model/SwiftDataAppContainer.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftData
 import SwiftUI
 
-func getCardsFromJSON() -> [Card] {
+func getCardsFromJSON() -> [CardJSON] {
     do {
         guard let urls = Bundle.main.urls(forResourcesWithExtension: "json", subdirectory: "data") else {
             fatalError("No data files found in bundle")
@@ -17,7 +17,7 @@ func getCardsFromJSON() -> [Card] {
 
         return try urls.flatMap { url in
             let data = try Data(contentsOf: url)
-            var cards = try JSONDecoder().decode([Card].self, from: data)
+            var cards = try JSONDecoder().decode([CardJSON].self, from: data)
 
             for c in cards.indices {
                 guard let rules = cards[c].rules else { continue }

--- a/App/Bunnydex/model/ThreadsafeBackgroundActor.swift
+++ b/App/Bunnydex/model/ThreadsafeBackgroundActor.swift
@@ -12,14 +12,14 @@ import Foundation
 actor ThreadsafeBackgroundActor: Sendable {
     private var context: ModelContext { modelExecutor.modelContext }
 
-    func fetchData(_ predicate: Predicate<CardModel>? = nil) throws -> [Card] {
+    func fetchData(_ predicate: Predicate<CardModel>? = nil) throws -> [CardView] {
         let descriptor = if let p = predicate {
             FetchDescriptor<CardModel>(predicate: p, sortBy: [SortDescriptor(\.rawDeck), SortDescriptor(\.cardId)])
         } else {
             FetchDescriptor<CardModel>(sortBy: [SortDescriptor(\.rawDeck), SortDescriptor(\.cardId)])
         }
         let cards = try context.fetch(descriptor)
-        return cards.map(Card.init)
+        return cards.map(CardView.init)
     }
 
     func initializeDatabase() {

--- a/App/Bunnydex/model/ThreadsafeBackgroundActor.swift
+++ b/App/Bunnydex/model/ThreadsafeBackgroundActor.swift
@@ -12,7 +12,7 @@ import Foundation
 actor ThreadsafeBackgroundActor: Sendable {
     private var context: ModelContext { modelExecutor.modelContext }
 
-    func fetchExperiment(_ predicate: Predicate<CardModel>? = nil) -> AsyncStream<[CardView]> {
+    func fetchData(_ predicate: Predicate<CardModel>? = nil) -> AsyncStream<[CardView]> {
         let descriptor = if let p = predicate {
             FetchDescriptor<CardModel>(predicate: p, sortBy: [SortDescriptor(\.rawDeck), SortDescriptor(\.cardId)])
         } else {
@@ -43,16 +43,6 @@ actor ThreadsafeBackgroundActor: Sendable {
                 // TODO: figure out error handling
             }
         }
-    }
-
-    func fetchData(_ predicate: Predicate<CardModel>? = nil) throws -> [CardView] {
-        let descriptor = if let p = predicate {
-            FetchDescriptor<CardModel>(predicate: p, sortBy: [SortDescriptor(\.rawDeck), SortDescriptor(\.cardId)])
-        } else {
-            FetchDescriptor<CardModel>(sortBy: [SortDescriptor(\.rawDeck), SortDescriptor(\.cardId)])
-        }
-        let cards = try context.fetch(descriptor)
-        return cards.map(CardView.init)
     }
 
     func initializeDatabase() {

--- a/App/Bunnydex/model/ThreadsafeBackgroundActor.swift
+++ b/App/Bunnydex/model/ThreadsafeBackgroundActor.swift
@@ -14,9 +14,9 @@ actor ThreadsafeBackgroundActor: Sendable {
 
     func fetchData(_ predicate: Predicate<CardModel>? = nil) throws -> [Card] {
         let descriptor = if let p = predicate {
-            FetchDescriptor<CardModel>(predicate: p, sortBy: [SortDescriptor(\.rawDeck), SortDescriptor(\.id)])
+            FetchDescriptor<CardModel>(predicate: p, sortBy: [SortDescriptor(\.rawDeck), SortDescriptor(\.cardId)])
         } else {
-            FetchDescriptor<CardModel>(sortBy: [SortDescriptor(\.rawDeck), SortDescriptor(\.id)])
+            FetchDescriptor<CardModel>(sortBy: [SortDescriptor(\.rawDeck), SortDescriptor(\.cardId)])
         }
         let cards = try context.fetch(descriptor)
         return cards.map(Card.init)

--- a/App/Bunnydex/view/CardDetailQueryView.swift
+++ b/App/Bunnydex/view/CardDetailQueryView.swift
@@ -20,7 +20,7 @@ struct CardDetailQueryView: View {
     init(id: String, path: Binding<NavigationPath>) {
         self._path = path
 
-        let predicate = #Predicate<CardModel> { $0.id == id }
+        let predicate = #Predicate<CardModel> { $0.cardId == id }
         _cards = Query(filter: predicate)
     }
 

--- a/App/Bunnydex/view/CardDetailQueryView.swift
+++ b/App/Bunnydex/view/CardDetailQueryView.swift
@@ -17,10 +17,10 @@ struct CardDetailQueryView: View {
 
     @Query private var cards: [CardModel]
 
-    init(id: String, path: Binding<NavigationPath>) {
+    init(id: PersistentIdentifier, path: Binding<NavigationPath>) {
         self._path = path
 
-        let predicate = #Predicate<CardModel> { $0.cardId == id }
+        let predicate = #Predicate<CardModel> { $0.persistentModelID == id }
         _cards = Query(filter: predicate)
     }
 
@@ -33,20 +33,20 @@ struct CardDetailQueryView: View {
     }
 }
 
-#Preview {
+#Preview(traits: .modifier(SampleData())) {
+    @Previewable @Query(filter: #Predicate<CardModel> { $0.cardId == "0185" }) var cards: [CardModel]
     @Previewable @State var path = NavigationPath()
 
     NavigationStack(path: $path) {
-        CardDetailQueryView(id: "0005", path: $path)
+        CardDetailQueryView(id: cards[0].id, path: $path)
     }
-    .modelContainer(previewContainer)
 }
 
-#Preview("Empty state") {
-    @Previewable @State var path = NavigationPath()
-
-    NavigationStack(path: $path) {
-        CardDetailQueryView(id: "INVALID", path: $path)
-    }
-    .modelContainer(previewContainer)
-}
+//#Preview("Empty state") {
+//    @Previewable @State var path = NavigationPath()
+//
+//    NavigationStack(path: $path) {
+//        CardDetailQueryView(id: .init(from: JSONDecoder()), path: $path)
+//    }
+//    .modelContainer(previewContainer)
+//}

--- a/App/Bunnydex/view/CardDetailQueryView.swift
+++ b/App/Bunnydex/view/CardDetailQueryView.swift
@@ -24,6 +24,13 @@ struct CardDetailQueryView: View {
         _cards = Query(filter: predicate)
     }
 
+    init(cardId: String, path: Binding<NavigationPath>) {
+        self._path = path
+
+        let predicate = #Predicate<CardModel> { $0.cardId == cardId }
+        _cards = Query(filter: predicate)
+    }
+
     var body: some View {
         if let card = cards.first {
             CardDetailView(card: card, path: $path)
@@ -39,14 +46,17 @@ struct CardDetailQueryView: View {
 
     NavigationStack(path: $path) {
         CardDetailQueryView(id: cards[0].id, path: $path)
+            .navigationDestination(for: String.self) { cardId in
+                CardDetailQueryView(cardId: cardId, path: $path)
+            }
     }
 }
 
-//#Preview("Empty state") {
-//    @Previewable @State var path = NavigationPath()
-//
-//    NavigationStack(path: $path) {
-//        CardDetailQueryView(id: .init(from: JSONDecoder()), path: $path)
-//    }
-//    .modelContainer(previewContainer)
-//}
+#Preview("Empty state") {
+    @Previewable @State var path = NavigationPath()
+
+    NavigationStack(path: $path) {
+        CardDetailQueryView(cardId: "Invalid", path: $path)
+    }
+    .modelContainer(previewContainer)
+}

--- a/App/Bunnydex/view/CardDetailView.swift
+++ b/App/Bunnydex/view/CardDetailView.swift
@@ -11,7 +11,7 @@ import SwiftData
 struct CardDetailView: View {
     let card: CardModel
     var imageId: String {
-        "01x\(card.deck.isKinder ? "K" : "Q")\(card.id)"
+        "01x\(card.deck.isKinder ? "K" : "Q")\(card.cardId)"
     }
     @Binding var path: NavigationPath
 
@@ -32,7 +32,7 @@ struct CardDetailView: View {
             }
             Section {
                 LabeledContent("ID") {
-                    Text(card.id)
+                    Text(card.cardId)
                 }
                 LabeledContent("Deck") {
                     Text(card.deck.description.display)
@@ -120,7 +120,7 @@ struct CardDetailView: View {
 }
 
 #Preview(traits: .modifier(SampleData())) {
-    @Previewable @Query(filter: #Predicate<CardModel> { $0.id == "0185" }) var cards: [CardModel]
+    @Previewable @Query(filter: #Predicate<CardModel> { $0.cardId == "0185" }) var cards: [CardModel]
     @Previewable @State var path = NavigationPath()
 
     NavigationStack(path: $path) {
@@ -129,7 +129,7 @@ struct CardDetailView: View {
 }
 
 #Preview("Home Button", traits: .modifier(SampleData())) {
-    @Previewable @Query(filter: #Predicate<CardModel> { $0.id == "0185" }) var cards: [CardModel]
+    @Previewable @Query(filter: #Predicate<CardModel> { $0.cardId == "0185" }) var cards: [CardModel]
     @Previewable @State var path = NavigationPath()
 
     NavigationStack(path: $path) {

--- a/App/Bunnydex/view/CardDetailView.swift
+++ b/App/Bunnydex/view/CardDetailView.swift
@@ -18,6 +18,7 @@ struct CardDetailView: View {
     @Environment(\.modelContext) var context
 
     @State private var showEditor = false
+    @State private var confirmDelete = false
 
     init(card: CardModel, path: Binding<NavigationPath>) {
         self.card = card
@@ -128,13 +129,15 @@ struct CardDetailView: View {
                         }
                         if card.custom {
                             ToolbarItem(placement: .topBarLeading) {
-                                Button {
-                                    context.delete(card)
-                                    showEditor = false
-                                    path.removeLast()
-                                } label: {
-                                    Text("Delete")
-                                        .foregroundStyle(.red)
+                                Button("Delete", role: .destructive) {
+                                    confirmDelete = true
+                                }
+                                .confirmationDialog("Are you sure?", isPresented: $confirmDelete) {
+                                    Button("Delete card", role: .destructive) {
+                                        context.delete(card)
+                                        showEditor = false
+                                        path.removeLast()
+                                    }
                                 }
                             }
                         }

--- a/App/Bunnydex/view/CardDetailView.swift
+++ b/App/Bunnydex/view/CardDetailView.swift
@@ -127,6 +127,8 @@ struct CardDetailView: View {
                         ToolbarItem(placement: .topBarLeading) {
                             Button {
                                 context.delete(card)
+                                try? context.save()
+
                                 showEditor = false
                                 path.removeLast()
                             } label: {

--- a/App/Bunnydex/view/CardDetailView.swift
+++ b/App/Bunnydex/view/CardDetailView.swift
@@ -15,6 +15,8 @@ struct CardDetailView: View {
     }
     @Binding var path: NavigationPath
 
+    @Environment(\.modelContext) var context
+
     @State private var showEditor = false
 
     init(card: CardModel, path: Binding<NavigationPath>) {
@@ -114,6 +116,24 @@ struct CardDetailView: View {
             NavigationStack {
                 CardEditView(card: card)
                     .navigationTitle("Edit Card")
+                    .toolbar {
+                        ToolbarItem {
+                            Button {
+                                showEditor = false
+                            } label: {
+                                Text("Done")
+                            }
+                        }
+                        ToolbarItem(placement: .topBarLeading) {
+                            Button {
+                                context.delete(card)
+                                showEditor = false
+                                path.removeLast()
+                            } label: {
+                                Text("Delete")
+                            }
+                        }
+                    }
             }
         }
     }

--- a/App/Bunnydex/view/CardDetailView.swift
+++ b/App/Bunnydex/view/CardDetailView.swift
@@ -112,7 +112,9 @@ struct CardDetailView: View {
                 Image(systemName: "pencil.circle")
             }
         }
-        .sheet(isPresented: $showEditor) {
+        .sheet(isPresented: $showEditor, onDismiss: {
+            try? context.save()
+        }) {
             NavigationStack {
                 CardEditView(card: card)
                     .navigationTitle("Edit Card")
@@ -124,15 +126,16 @@ struct CardDetailView: View {
                                 Text("Done")
                             }
                         }
-                        ToolbarItem(placement: .topBarLeading) {
-                            Button {
-                                context.delete(card)
-                                try? context.save()
-
-                                showEditor = false
-                                path.removeLast()
-                            } label: {
-                                Text("Delete")
+                        if card.custom {
+                            ToolbarItem(placement: .topBarLeading) {
+                                Button {
+                                    context.delete(card)
+                                    showEditor = false
+                                    path.removeLast()
+                                } label: {
+                                    Text("Delete")
+                                        .foregroundStyle(.red)
+                                }
                             }
                         }
                     }

--- a/App/Bunnydex/view/CardDetailView.swift
+++ b/App/Bunnydex/view/CardDetailView.swift
@@ -113,6 +113,7 @@ struct CardDetailView: View {
         .sheet(isPresented: $showEditor) {
             NavigationStack {
                 CardEditView(card: card)
+                    .navigationTitle("Edit Card")
             }
         }
     }

--- a/App/Bunnydex/view/CardEditView.swift
+++ b/App/Bunnydex/view/CardEditView.swift
@@ -18,7 +18,7 @@ struct CardEditView: View {
         Form {
             Section("Required Fields") {
                 LabeledContent("ID") {
-                    TextField("0000", text: $card.id)
+                    TextField("0000", text: $card.cardId)
                         .multilineTextAlignment(.trailing)
                 }
                 LabeledContent("Title") {
@@ -76,7 +76,7 @@ struct CardEditView: View {
 }
 
 #Preview(traits: .modifier(SampleData())) {
-    @Previewable @Query(filter: #Predicate<CardModel> { $0.id == "0185" }) var cards: [CardModel]
+    @Previewable @Query(filter: #Predicate<CardModel> { $0.cardId == "0185" }) var cards: [CardModel]
 
     NavigationStack {
         CardEditView(card: cards[0])

--- a/App/Bunnydex/view/CardEditView.swift
+++ b/App/Bunnydex/view/CardEditView.swift
@@ -72,7 +72,6 @@ struct CardEditView: View {
                 Text("Touch and hold to reorder. Swipe left to delete.")
             }
         }
-        .navigationTitle("Edit Card")
     }
 }
 
@@ -81,5 +80,6 @@ struct CardEditView: View {
 
     NavigationStack {
         CardEditView(card: cards[0])
+            .navigationTitle("Edit Card")
     }
 }

--- a/App/Bunnydex/view/CardListView.swift
+++ b/App/Bunnydex/view/CardListView.swift
@@ -20,8 +20,8 @@ class CardListViewModel {
     private(set) var state = State.idle
     private var lastFilter: CardPredicate?
 
-    func load(container: ModelContainer, filter: CardPredicate) async {
-        if let lastFilter = lastFilter, lastFilter == filter {
+    func load(container: ModelContainer, filter: CardPredicate, force: Bool = false) async {
+        if let lastFilter = lastFilter, lastFilter == filter && !force {
             return
         }
 
@@ -50,10 +50,12 @@ struct CardListView: View {
     @Environment(\.modelContext) private var context
     @Binding var path: NavigationPath
     @Binding var cardFilter: CardPredicate
+    @Binding var forceReload: Int
 
-    init(path: Binding<NavigationPath>, cardFilter: Binding<CardPredicate> = .constant(.init())) {
+    init(path: Binding<NavigationPath>, cardFilter: Binding<CardPredicate> = .constant(.init()), forceReload: Binding<Int> = .constant(0)) {
         _path = path
         _cardFilter = cardFilter
+        _forceReload = forceReload
     }
 
     var body: some View {
@@ -88,6 +90,9 @@ struct CardListView: View {
         }
         .task(id: cardFilter) {
             await viewModel.load(container: context.container, filter: cardFilter)
+        }
+        .task(id: forceReload) {
+            await viewModel.load(container: context.container, filter: cardFilter, force: true)
         }
     }
 }

--- a/App/Bunnydex/view/CardListView.swift
+++ b/App/Bunnydex/view/CardListView.swift
@@ -14,7 +14,7 @@ class CardListViewModel {
         case idle
         case loading
         case failed(Error)
-        case loaded([Card])
+        case loaded([CardView])
     }
 
     private(set) var state = State.idle
@@ -39,7 +39,7 @@ class CardListViewModel {
         }
     }
 
-    nonisolated func fetchData(container: ModelContainer, predicate: Predicate<CardModel>) async throws -> [Card] {
+    nonisolated func fetchData(container: ModelContainer, predicate: Predicate<CardModel>) async throws -> [CardView] {
         let service = ThreadsafeBackgroundActor(modelContainer: container)
         return try await service.fetchData(predicate)
     }
@@ -70,7 +70,7 @@ struct CardListView: View {
             case .loaded(let cards):
                 List {
                     ForEach(cards) { card in
-                        NavigationLink("\(card.id) — \(card.title)", value: card.id)
+                        NavigationLink("\(card.cardId) — \(card.title)", value: card.id)
                     }
                 }
                 .overlay {
@@ -85,7 +85,7 @@ struct CardListView: View {
             }
         }
         .navigationTitle("Cards")
-        .navigationDestination(for: String.self) { id in
+        .navigationDestination(for: PersistentIdentifier.self) { id in
             CardDetailQueryView(id: id, path: $path)
         }
         .task(id: cardFilter) {

--- a/App/Bunnydex/view/CardListView.swift
+++ b/App/Bunnydex/view/CardListView.swift
@@ -19,13 +19,15 @@ class CardListViewModel {
 
     private(set) var state = State.idle
     private var lastFilter: CardPredicate?
+    private var lastReloadCount = 0
 
-    func load(container: ModelContainer, filter: CardPredicate, force: Bool = false) async {
-        if let lastFilter = lastFilter, lastFilter == filter && !force {
+    func load(container: ModelContainer, filter: CardPredicate, reloadCount: Int = 0) async {
+        if let lastFilter = lastFilter, lastFilter == filter && lastReloadCount == reloadCount {
             return
         }
 
         state = .loading
+        lastReloadCount = reloadCount
 
         do {
             try await Task.sleep(nanoseconds: 250_000_000)
@@ -92,10 +94,10 @@ struct CardListView: View {
             CardDetailQueryView(cardId: cardId, path: $path)
         }
         .task(id: cardFilter) {
-            await viewModel.load(container: context.container, filter: cardFilter)
+            await viewModel.load(container: context.container, filter: cardFilter, reloadCount: forceReload)
         }
         .task(id: forceReload) {
-            await viewModel.load(container: context.container, filter: cardFilter, force: true)
+            await viewModel.load(container: context.container, filter: cardFilter, reloadCount: forceReload)
         }
     }
 }

--- a/App/Bunnydex/view/CardListView.swift
+++ b/App/Bunnydex/view/CardListView.swift
@@ -88,6 +88,9 @@ struct CardListView: View {
         .navigationDestination(for: PersistentIdentifier.self) { id in
             CardDetailQueryView(id: id, path: $path)
         }
+        .navigationDestination(for: String.self) { cardId in
+            CardDetailQueryView(cardId: cardId, path: $path)
+        }
         .task(id: cardFilter) {
             await viewModel.load(container: context.container, filter: cardFilter)
         }

--- a/App/Bunnydex/view/CardListView.swift
+++ b/App/Bunnydex/view/CardListView.swift
@@ -36,6 +36,7 @@ class CardListViewModel {
         observationTask?.cancel()
         observationTask = Task { [weak self] in
             guard let stream = await self?.fetchData(container: container, predicate: filter.predicate) else { return }
+            self?.lastFilter = filter
 
             for await cards in stream {
                 self?.state = .loaded(cards)

--- a/App/Bunnydex/view/ContentView.swift
+++ b/App/Bunnydex/view/ContentView.swift
@@ -17,6 +17,7 @@ struct ContentView: View {
     @State private var path = NavigationPath()
 
     @State private var isCreatingDatabase = true
+    @State private var reloadList = 0
 
     @Environment(\.modelContext) private var context
 
@@ -25,7 +26,7 @@ struct ContentView: View {
             if isCreatingDatabase {
                 ProgressView("Creating database")
             } else {
-                CardListView(path: $path, cardFilter: $cardPredicate)
+                CardListView(path: $path, cardFilter: $cardPredicate, forceReload: $reloadList)
                     .searchable(text: $cardPredicate.searchFilter, prompt: "Search")
                 .toolbar {
                     ToolbarItem {
@@ -66,7 +67,10 @@ struct ContentView: View {
                     }
                 }
             }
-        }.sheet(item: $addedModel) { card in
+        }.sheet(item: $addedModel, onDismiss: {
+            try? context.save()
+            reloadList += 1
+        }) { card in
             NavigationStack {
                 CardEditView(card: card)
                     .navigationTitle("Add Card")

--- a/App/Bunnydex/view/ContentView.swift
+++ b/App/Bunnydex/view/ContentView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import SwiftData
 
 struct ContentView: View {
-    @State private var showAddCard: Bool = false
+    @State private var addedModel: CardModel?
     @State private var showFilters: Bool = false
 
     @State private var cardPredicate = CardPredicate()
@@ -30,7 +30,9 @@ struct ContentView: View {
                 .toolbar {
                     ToolbarItem {
                         Button {
-                            showAddCard.toggle()
+                            let newCard = CardModel()
+                            context.insert(newCard)
+                            addedModel = newCard
                         } label: {
                             Image(systemName: "plus.circle")
                         }
@@ -64,9 +66,9 @@ struct ContentView: View {
                     }
                 }
             }
-        }.sheet(isPresented: $showAddCard) {
+        }.sheet(item: $addedModel) { card in
             NavigationStack {
-                CardEditView(card: .init())
+                CardEditView(card: card)
                     .navigationTitle("Add Card")
             }
         }.sheet(isPresented: $showFilters) {

--- a/App/Bunnydex/view/ContentView.swift
+++ b/App/Bunnydex/view/ContentView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 import SwiftData
 
 struct ContentView: View {
-    @State private var showInfo: Bool = false
     @State private var showFilters: Bool = false
 
     @State private var cardPredicate = CardPredicate()
@@ -28,11 +27,18 @@ struct ContentView: View {
                 CardListView(path: $path, cardFilter: $cardPredicate)
                     .searchable(text: $cardPredicate.searchFilter, prompt: "Search")
                 .toolbar {
+                    ToolbarItem {
+                        Button {
+                            print("Add card")
+                        } label: {
+                            Image(systemName: "plus.circle")
+                        }
+                    }
                     ToolbarItem(placement: .topBarLeading) {
                         Button {
-                            showInfo.toggle()
+                            showFilters.toggle()
                         } label: {
-                            Image(systemName: "info.circle")
+                            Image(systemName: "line.3.horizontal.decrease.circle")
                         }
                     }
                     if !cardPredicate.decks.isEmpty
@@ -42,7 +48,7 @@ struct ContentView: View {
                         || !cardPredicate.dice.isEmpty
                         || !cardPredicate.symbols.isEmpty
                     {
-                        ToolbarItem {
+                        ToolbarItem(placement: .topBarLeading) {
                             Button {
                                 cardPredicate.decks.removeAll()
                                 cardPredicate.types.removeAll()
@@ -55,17 +61,8 @@ struct ContentView: View {
                             }
                         }
                     }
-                    ToolbarItem {
-                        Button {
-                            showFilters.toggle()
-                        } label: {
-                            Image(systemName: "line.3.horizontal.decrease.circle")
-                        }
-                    }
                 }
             }
-        }.sheet(isPresented: $showInfo) {
-            InfoView()
         }.sheet(isPresented: $showFilters) {
             FilterView(cardFilter: $cardPredicate, expandState: $expandState)
         }.task {

--- a/App/Bunnydex/view/ContentView.swift
+++ b/App/Bunnydex/view/ContentView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import SwiftData
 
 struct ContentView: View {
+    @State private var showAddCard: Bool = false
     @State private var showFilters: Bool = false
 
     @State private var cardPredicate = CardPredicate()
@@ -29,7 +30,7 @@ struct ContentView: View {
                 .toolbar {
                     ToolbarItem {
                         Button {
-                            print("Add card")
+                            showAddCard.toggle()
                         } label: {
                             Image(systemName: "plus.circle")
                         }
@@ -62,6 +63,11 @@ struct ContentView: View {
                         }
                     }
                 }
+            }
+        }.sheet(isPresented: $showAddCard) {
+            NavigationStack {
+                CardEditView(card: .init())
+                    .navigationTitle("Add Card")
             }
         }.sheet(isPresented: $showFilters) {
             FilterView(cardFilter: $cardPredicate, expandState: $expandState)

--- a/App/Bunnydex/view/ContentView.swift
+++ b/App/Bunnydex/view/ContentView.swift
@@ -74,7 +74,25 @@ struct ContentView: View {
             NavigationStack {
                 CardEditView(card: card)
                     .navigationTitle("Add Card")
+                    .toolbar {
+                        ToolbarItem {
+                            Button {
+                                addedModel = nil
+                            } label: {
+                                Text("Save")
+                            }
+                        }
+                        ToolbarItem(placement: .topBarLeading) {
+                            Button {
+                                context.delete(addedModel!)
+                                addedModel = nil
+                            } label: {
+                                Text("Cancel")
+                            }
+                        }
+                    }
             }
+            .interactiveDismissDisabled()
         }.sheet(isPresented: $showFilters) {
             FilterView(cardFilter: $cardPredicate, expandState: $expandState)
         }.task {

--- a/App/Bunnydex/view/ContentView.swift
+++ b/App/Bunnydex/view/ContentView.swift
@@ -84,7 +84,7 @@ struct ContentView: View {
                         }
                         ToolbarItem(placement: .topBarLeading) {
                             Button {
-                                context.delete(addedModel!)
+                                context.delete(card)
                                 addedModel = nil
                             } label: {
                                 Text("Cancel")

--- a/App/Bunnydex/view/ContentView.swift
+++ b/App/Bunnydex/view/ContentView.swift
@@ -17,7 +17,6 @@ struct ContentView: View {
     @State private var path = NavigationPath()
 
     @State private var isCreatingDatabase = true
-    @State private var reloadList = 0
 
     @Environment(\.modelContext) private var context
 
@@ -26,7 +25,7 @@ struct ContentView: View {
             if isCreatingDatabase {
                 ProgressView("Creating database")
             } else {
-                CardListView(path: $path, cardFilter: $cardPredicate, forceReload: $reloadList)
+                CardListView(path: $path, cardFilter: $cardPredicate)
                     .searchable(text: $cardPredicate.searchFilter, prompt: "Search")
                 .toolbar {
                     ToolbarItem {
@@ -69,7 +68,6 @@ struct ContentView: View {
             }
         }.sheet(item: $addedModel, onDismiss: {
             try? context.save()
-            reloadList += 1
         }) { card in
             NavigationStack {
                 CardEditView(card: card)

--- a/App/Bunnydex/view/InfoView.swift
+++ b/App/Bunnydex/view/InfoView.swift
@@ -19,7 +19,6 @@ let infoText = """
                 """
 
 struct InfoView: View {
-    @Environment(\.dismiss) var dismiss
     #if DEBUG
     @Environment(\.modelContext) var context
     @State private var loadingTask: Task<Void, Never>?
@@ -49,13 +48,6 @@ struct InfoView: View {
                 }
                 .disabled(isLoading)
                 #endif
-            }
-            .toolbar {
-                ToolbarItem {
-                    Button("Done") {
-                        dismiss()
-                    }
-                }
             }
         }
     }

--- a/App/Bunnydex/view/MainView.swift
+++ b/App/Bunnydex/view/MainView.swift
@@ -1,0 +1,28 @@
+//
+//  MainView.swift
+//  Bunnydex
+//
+//  Created by Neill Robson on 7/25/25.
+//
+
+import SwiftUI
+
+struct MainView: View {
+    var body: some View {
+        TabView {
+            ContentView()
+                .tabItem {
+                    Label("Browse", systemImage: "list.bullet.rectangle.portrait")
+                }
+            InfoView()
+                .tabItem {
+                    Label("About", systemImage: "info")
+                }
+        }
+    }
+}
+
+#Preview {
+    MainView()
+        .modelContainer(appContainer)
+}


### PR DESCRIPTION
Closes GH-36.

An insane amount of refactoring in here. Essentially, had to rebuild a lot of SwiftData infrastructure so that creating new cards would elicit proactive UI updates... without crashing the DB.

Will probably still consider:

- [ ] Refactoring the UI to remove the need for the bottom tab bar
- [x] Disable deletion of standard cards
- [x] Add deletion confirmation modal